### PR TITLE
don't write the pub key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,6 @@ jobs:
         with:
           gpg_private_key: ${{ steps.secrets.outputs.token }}
 
-      - run: |
-          gpg --export --armor ${{ steps.import_gpg.outputs.fingerprint }}
-
       - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: latest


### PR DESCRIPTION
this writes it to the repo and puts the tree in a dirty state:

```
⨯ release failed after 0s                 
    error=
    │ git is in a dirty state
    │ Please check in your pipeline what can be changing the following files:
    │ ?? gha-creds-d720590a[37](https://github.com/chainguard-dev/terraform-provider-helm/actions/runs/14843155742/job/41670684853#step:10:38)157b4e.json
    │ Learn more at https://goreleaser.com/errors/dirty
```