### PR TITLE
add support for last mile json patching

### DIFF
--- a/docs/resources/chart.md
+++ b/docs/resources/chart.md
@@ -22,6 +22,7 @@ Manages a Helm chart in an OCI registry from an APK package.
 
 ### Optional
 
+- `json_patches` (Map of String) JSON RFC6902 patches to apply to the Helm chart, organized by the file to which the patch should be applied. Each file must contain the json representation of the JSON patch array to apply. It's easiest to use the jsonencode function to generate the JSON string.
 - `package_arch` (String) The architecture of the package to fetch. If not specified, uses the provider default_arch or falls back to system defaults.
 - `package_version` (String) The version of the package to fetch from the package repository. If not specified, the latest available version will be used.
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.2
 
 require (
 	chainguard.dev/apko v0.27.4
+	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/google/go-containerregistry v0.20.3
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
we don't want the wild west of last mile patching, so this leverages the json RFC6902 style of patches ala kustomize to allow customization at chart packaging time. json RFC6902 patches are specifically chosen since they operate exclusively on json structured data, meaning this opt-in patching is only ever intended for use with "simple" patches to things like `values.yaml` or `Chart.yaml`. 

this is **not** intended to customize any `.tpl` files, something this provider is likely never going to support.