### PR TITLE
Rename E2E test registry to registry.localhost to fix chart pushes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,11 @@ jobs:
 
       - name: Set up kind
         uses: chainguard-dev/actions/setup-kind@5f020827ba80ff5d64d45116542d0c733e8e7e71 # v1.6.23
+        with:
+          # go-containerregistry only auto-detects *.localhost hostnames as
+          # plain-HTTP registries, so the default registry.local would be
+          # dialed over HTTPS and fail.
+          registry-authority: registry.localhost:5000
 
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/e2e-tests/e2e.sh
+++ b/e2e-tests/e2e.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 REPO_ROOT="$( cd "$SCRIPT_DIR/.." &> /dev/null && pwd )"
 TEMP_DIR=$(mktemp -d)
-REGISTRY=${REGISTRY:-registry.local:5000}
+REGISTRY=${REGISTRY:-registry.localhost:5000}
 
 # Cleanup function
 cleanup() {


### PR DESCRIPTION
go-containerregistry v0.21.6 narrowed its plain-HTTP registry auto-detection to *.localhost hostnames only (google/go-containerregistry#2281), so pushes to registry.local:5000 started dialing HTTPS against the HTTP-only kind registry and failing with "server gave HTTP response to HTTPS client". The apko 1.2.29 bump pulled that version in transitively, breaking E2E on main and every PR since. Renaming the registry authority to registry.localhost:5000 restores the auto-detection.
